### PR TITLE
Replace bold with code

### DIFF
--- a/ajax-javascript-api.md
+++ b/ajax-javascript-api.md
@@ -19,29 +19,29 @@ The second argument of the `request` method is the options object. You can use a
 
 Option | Description
 ------------- | -------------
-**update** | an object, specifies a list partials and page elements (as CSS selectors) to update: {'partial': '#select'}. If the selector string is prepended with the `@` symbol, the content received from the server will be appended to the element, instead of replacing the existing content.
-**confirm** | the confirmation string. If set, the confirmation is displayed before the request is sent. If the user clicks the Cancel button, the request cancels.
-**data** | an optional object specifying data to be sent to the server along with the form data: {var: 'value'}. When `files` is true, you may also include files to be uploaded in this object by using [`Blob` objects](https://developer.mozilla.org/en-US/docs/Web/API/Blob). To specify the filename of any `Blob` objects, simply set the `filename` property on the `Blob` object. (Ex. `var blob = new Blob(variable); blob.filename = 'test.txt'; var data = {'uploaded_file': blob};`)
-**redirect** | string specifying an URL to redirect the browser to after the successful request.
-**beforeUpdate** | a callback function to execute before page elements are updated. The function gets 3 parameters: the data object received from the server, text status string, and the jqXHR object. The `this` variable inside the function resolves to the request content - an object containing 2 properties: `handler` and `options` representing the original request() parameters.
-**success** | a callback function to execute in case of a successful request. If this option is supplied it overrides the default framework's functionality: the elements are not updated, the `beforeUpdate` event is not triggered, the `ajaxUpdate` and `ajaxUpdateComplete` events are not triggered. The event handler gets 3 arguments: the data object received from the server, the text status string and the jqXHR object. However, you can still call the default framework functionality calling `this.success(...)` inside your function.
-**error** | a callback function execute in case of an error. By default the alert message is displayed. If this option is overridden the alert message won't be displayed. The handler gets 3 parameters: the jqXHR object, the text status string and the error object - see [jQuery AJAX function](http://api.jquery.com/jQuery.ajax/).
-**complete** | a callback function execute in case of a success or an error.
-**form** | a form element to use for sourcing the form data sent with the request, either passed as a selector string or a form element.
-**flash** | when true, instructs the server to clear and send any flash messages with the response. default: false
-**files** | when true, the request will accept file uploads, this requires `FormData` interface support by the browser. default: false
-**browserValidate** | when true, browser-based client side validation will be performed on the request before submitting. This only applies to requests triggered in the context of a `<form>` element. **NOTE:** This form of validation does not play nice with complex forms where validated fields might not be visible to the user 100% of the time. Recommend that you avoid using it on anything but the most simple forms.
-**loading** | an optional string or object to be displayed when a request runs. The string should be a CSS selector for an element, the object should support the `show()` and `hide()` functions to manage the visibility. You may pass the global object `$.wn.stripeLoadIndicator` when using the [framework extras](../ajax/extras).
+`update` | an object, specifies a list partials and page elements (as CSS selectors) to update: {'partial': '#select'}. If the selector string is prepended with the `@` symbol, the content received from the server will be appended to the element, instead of replacing the existing content.
+`confirm` | the confirmation string. If set, the confirmation is displayed before the request is sent. If the user clicks the Cancel button, the request cancels.
+`data` | an optional object specifying data to be sent to the server along with the form data: {var: 'value'}. When `files` is true, you may also include files to be uploaded in this object by using [`Blob` objects](https://developer.mozilla.org/en-US/docs/Web/API/Blob). To specify the filename of any `Blob` objects, simply set the `filename` property on the `Blob` object. (Ex. `var blob = new Blob(variable); blob.filename = 'test.txt'; var data = {'uploaded_file': blob};`)
+`redirect` | string specifying an URL to redirect the browser to after the successful request.
+`beforeUpdate` | a callback function to execute before page elements are updated. The function gets 3 parameters: the data object received from the server, text status string, and the jqXHR object. The `this` variable inside the function resolves to the request content - an object containing 2 properties: `handler` and `options` representing the original request() parameters.
+`success` | a callback function to execute in case of a successful request. If this option is supplied it overrides the default framework's functionality: the elements are not updated, the `beforeUpdate` event is not triggered, the `ajaxUpdate` and `ajaxUpdateComplete` events are not triggered. The event handler gets 3 arguments: the data object received from the server, the text status string and the jqXHR object. However, you can still call the default framework functionality calling `this.success(...)` inside your function.
+`error` | a callback function execute in case of an error. By default the alert message is displayed. If this option is overridden the alert message won't be displayed. The handler gets 3 parameters: the jqXHR object, the text status string and the error object - see [jQuery AJAX function](http://api.jquery.com/jQuery.ajax/).
+`complete` | a callback function execute in case of a success or an error.
+`form` | a form element to use for sourcing the form data sent with the request, either passed as a selector string or a form element.
+`flash` | when true, instructs the server to clear and send any flash messages with the response. default: false
+`files` | when true, the request will accept file uploads, this requires `FormData` interface support by the browser. default: false
+`browserValidate` | when true, browser-based client side validation will be performed on the request before submitting. This only applies to requests triggered in the context of a `<form>` element. **NOTE:** This form of validation does not play nice with complex forms where validated fields might not be visible to the user 100% of the time. Recommend that you avoid using it on anything but the most simple forms.
+`loading` | an optional string or object to be displayed when a request runs. The string should be a CSS selector for an element, the object should support the `show()` and `hide()` functions to manage the visibility. You may pass the global object `$.wn.stripeLoadIndicator` when using the [framework extras](../ajax/extras).
 
 You may also override some of the request logic by passing new functions as options. These logic handlers are available.
 
 Handler | Description
 ------------- | -------------
-**handleConfirmMessage(message)** | called when requesting confirmation from the user.
-**handleErrorMessage(message)** | called when an error message should be displayed.
-**handleValidationMessage(message, fields)** | focuses the first invalid field when validation is used.
-**handleFlashMessage(message, type)** | called when a flash message is provided using the **flash** option (see above).
-**handleRedirectResponse(url)** | called when the browser should redirect to another location.
+`handleConfirmMessage(message)` | called when requesting confirmation from the user.
+`handleErrorMessage(message)` | called when an error message should be displayed.
+`handleValidationMessage(message, fields)` | focuses the first invalid field when validation is used.
+`handleFlashMessage(message, type)` | called when a flash message is provided using the **flash** option (see above).
+`handleRedirectResponse(url)` | called when the browser should redirect to another location.
 
 <a name="javascript-examples"></a>
 ## Usage examples
@@ -100,24 +100,24 @@ The AJAX framework triggers several events on the updated elements, triggering e
 
 Event | Description
 ------------- | -------------
-**ajaxBeforeSend** | triggered on the window object before sending the request.
-**ajaxBeforeUpdate** | triggered on the form object directly after the request is complete, but before the page is updated. The handler gets 5 parameters: the event object, the context object, the data object received from the server, the status text string, and the jqXHR object.
-**ajaxUpdate** | triggered on a page element after it has been updated with the framework. The handler gets 5 parameters: the event object, the context object, the data object received from the server, the status text string, and the jqXHR object.
-**ajaxUpdateComplete** | triggered on the window object after all elements are updated by the framework. The handler gets 5 parameters: the event object, the context object, the data object received from the server, the status text string, and the jqXHR object.
-**ajaxSuccess** | triggered on the form object after the request is successfully completed. The handler gets 5 parameters: the event object, the context object, the data object received from the server, the status text string, and the jqXHR object.
-**ajaxError** | triggered on the form object if the request encounters an error. The handler gets 5 parameters: the event object, the context object, the error message, the status text string, and the jqXHR object.
-**ajaxErrorMessage** | triggered on the window object if the request encounters an error. The handler gets 2 parameters: the event object and error message returned from the server.
-**ajaxConfirmMessage** | triggered on the window object when `confirm` option is given. The handler gets 2 parameters: the event object and text message assigned to the handler as part of `confirm` option. This is useful for implementing custom confirm logic/interface instead of native javascript confirm box.
+`ajaxBeforeSend` | triggered on the window object before sending the request.
+`ajaxBeforeUpdate` | triggered on the form object directly after the request is complete, but before the page is updated. The handler gets 5 parameters: the event object, the context object, the data object received from the server, the status text string, and the jqXHR object.
+`ajaxUpdate` | triggered on a page element after it has been updated with the framework. The handler gets 5 parameters: the event object, the context object, the data object received from the server, the status text string, and the jqXHR object.
+`ajaxUpdateComplete` | triggered on the window object after all elements are updated by the framework. The handler gets 5 parameters: the event object, the context object, the data object received from the server, the status text string, and the jqXHR object.
+`ajaxSuccess` | triggered on the form object after the request is successfully completed. The handler gets 5 parameters: the event object, the context object, the data object received from the server, the status text string, and the jqXHR object.
+`ajaxError` | triggered on the form object if the request encounters an error. The handler gets 5 parameters: the event object, the context object, the error message, the status text string, and the jqXHR object.
+`ajaxErrorMessage` | triggered on the window object if the request encounters an error. The handler gets 2 parameters: the event object and error message returned from the server.
+`ajaxConfirmMessage` | triggered on the window object when `confirm` option is given. The handler gets 2 parameters: the event object and text message assigned to the handler as part of `confirm` option. This is useful for implementing custom confirm logic/interface instead of native javascript confirm box.
 
 These events are fired on the triggering element:
 
 Event | Description
 ------------- | -------------
-**ajaxSetup** | triggered before the request is formed, allowing options to be modified via the `context.options` object.
-**ajaxPromise** | triggered directly before the AJAX request is sent.
-**ajaxFail** | triggered finally if the AJAX request fails.
-**ajaxDone** | triggered finally if the AJAX request was successful.
-**ajaxAlways** | triggered regardless if the AJAX request fails or was successful.
+`ajaxSetup` | triggered before the request is formed, allowing options to be modified via the `context.options` object.
+`ajaxPromise` | triggered directly before the AJAX request is sent.
+`ajaxFail` | triggered finally if the AJAX request fails.
+`ajaxDone` | triggered finally if the AJAX request was successful.
+`ajaxAlways` | triggered regardless if the AJAX request fails or was successful.
 
 <a name="global-events-examples"></a>
 ## Usage examples

--- a/database-model.md
+++ b/database-model.md
@@ -80,17 +80,17 @@ There are some standard properties that can be found on models, in addition to t
 
 Property | Description
 ------------- | -------------
-**$primaryKey** | primary key name used to identify the model.
-**$incrementing** | boolean that if false indicates that the primary key is not an incrementing integer value.
-**$exists** | boolean that if true indicates that the model exists.
-**$dates** | values are converted to an instance of Carbon/DateTime objects after fetching.
-**$timestamps** | boolean that if true will automatically set created_at and updated_at fields.
-**$jsonable** | values are encoded as JSON before saving and converted to arrays after fetching.
-**$fillable** | values are fields accessible to [mass assignment](#mass-assignment).
-**$guarded** | values are fields guarded from [mass assignment](#mass-assignment).
-**$visible** | values are fields made visible when [serializing the model data](../database/serialization).
-**$hidden** | values are fields made hidden when [serializing the model data](../database/serialization).
-**$connection** | string that contains the [connection name](../database/basics#accessing-connections) that's utilised by the model by default.
+`$primaryKey` | primary key name used to identify the model.
+`$incrementing` | boolean that if false indicates that the primary key is not an incrementing integer value.
+`$exists` | boolean that if true indicates that the model exists.
+`$dates` | values are converted to an instance of Carbon/DateTime objects after fetching.
+`$timestamps` | boolean that if true will automatically set created_at and updated_at fields.
+`$jsonable` | values are encoded as JSON before saving and converted to arrays after fetching.
+`$fillable` | values are fields accessible to [mass assignment](#mass-assignment).
+`$guarded` | values are fields guarded from [mass assignment](#mass-assignment).
+`$visible` | values are fields made visible when [serializing the model data](../database/serialization).
+`$hidden` | values are fields made hidden when [serializing the model data](../database/serialization).
+`$connection` | string that contains the [connection name](../database/basics#accessing-connections) that's utilised by the model by default.
 
 <a name="property-primary-key"></a>
 #### Primary key
@@ -566,20 +566,20 @@ Models fire several events, allowing you to hook into various points in the mode
 
 Event | Description
 ------------- | -------------
-**beforeCreate** | before the model is saved, when first created.
-**afterCreate** | after the model is saved, when first created.
-**beforeSave** | before the model is saved, either created or updated.
-**afterSave** | after the model is saved, either created or updated.
-**beforeValidate** | before the supplied model data is validated.
-**afterValidate** | after the supplied model data has been validated.
-**beforeUpdate** | before an existing model is saved.
-**afterUpdate** | after an existing model is saved.
-**beforeDelete** | before an existing model is deleted.
-**afterDelete** | after an existing model is deleted.
-**beforeRestore** | before a soft-deleted model is restored.
-**afterRestore** | after a soft-deleted model has been restored.
-**beforeFetch** | before an existing model is populated.
-**afterFetch** | after an existing model has been populated.
+`beforeCreate` | before the model is saved, when first created.
+`afterCreate` | after the model is saved, when first created.
+`beforeSave` | before the model is saved, either created or updated.
+`afterSave` | after the model is saved, either created or updated.
+`beforeValidate` | before the supplied model data is validated.
+`afterValidate` | after the supplied model data has been validated.
+`beforeUpdate` | before an existing model is saved.
+`afterUpdate` | after an existing model is saved.
+`beforeDelete` | before an existing model is deleted.
+`afterDelete` | after an existing model is deleted.
+`beforeRestore` | before a soft-deleted model is restored.
+`afterRestore` | after a soft-deleted model has been restored.
+`beforeFetch` | before an existing model is populated.
+`afterFetch` | after an existing model has been populated.
 
 An example of using an event:
 

--- a/database-relations.md
+++ b/database-relations.md
@@ -70,13 +70,13 @@ The following are parameters that can be used with all relations:
 
 Argument | Description
 ------------- | -------------
-**order** | sorting order for multiple records.
-**conditions** | filters the relation using a raw where query statement.
-**scope** | filters the relation using a supplied scope method.
-**push** | if set to false, this relation will not be saved via `push`, default: true.
-**delete** | if set to true, the related model will be deleted if the primary model is deleted or relationship is destroyed, default: false.
-**detach** | if set to false the related model will not be automatically detached if the primary model is deleted or the relationship is destroyed. Used by `belongsToMany` relationships only, default: true.
-**count** | if set to true, the result contains a `count` column only, used for counting relations, default: false.
+`order` | sorting order for multiple records.
+`conditions` | filters the relation using a raw where query statement.
+`scope` | filters the relation using a supplied scope method.
+`push` | if set to false, this relation will not be saved via `push`, default: true.
+`delete` | if set to true, the related model will be deleted if the primary model is deleted or relationship is destroyed, default: false.
+`detach` | if set to false the related model will not be automatically detached if the primary model is deleted or the relationship is destroyed. Used by `belongsToMany` relationships only, default: true.
+`count` | if set to true, the result contains a `count` column only, used for counting relations, default: false.
 
 Example filter using **order** and **conditions**:
 
@@ -356,14 +356,14 @@ These are the parameters supported for `belongsToMany` relations:
 
 Argument | Description
 ------------- | -------------
-**table** | the name of the join table.
-**key** | the key column name of the defining model (inside pivot table). Default value is combined from model name and `_id` suffix, i.e. `user_id`
-**parentKey** | the key column name of the defining model (inside defining model table). Default: id
-**otherKey** | the key column name of the related model (inside pivot table). Default value is combined from model name and `_id` suffix, i.e. `role_id`
-**relatedKey** | the key column name of the related model (inside related model table). Default: id
-**pivot** | an array of pivot columns found in the join table, attributes are available via `$model->pivot`.
-**pivotModel** | specify a custom model class to return when accessing the pivot relation. Defaults to `Winter\Storm\Database\Pivot`.
-**timestamps** | if true, the join table should contain `created_at` and `updated_at` columns. Default: false
+`table` | the name of the join table.
+`key` | the key column name of the defining model (inside pivot table). Default value is combined from model name and `_id` suffix, i.e. `user_id`
+`parentKey` | the key column name of the defining model (inside defining model table). Default: id
+`otherKey` | the key column name of the related model (inside pivot table). Default value is combined from model name and `_id` suffix, i.e. `role_id`
+`relatedKey` | the key column name of the related model (inside related model table). Default: id
+`pivot` | an array of pivot columns found in the join table, attributes are available via `$model->pivot`.
+`pivotModel` | specify a custom model class to return when accessing the pivot relation. Defaults to `Winter\Storm\Database\Pivot`.
+`timestamps` | if true, the join table should contain `created_at` and `updated_at` columns. Default: false
 
 <a name="has-many-through"></a>
 ### Has Many Through

--- a/plugin-components.md
+++ b/plugin-components.md
@@ -111,18 +111,18 @@ The method should return an array with the property keys as indexes and property
 
 Key | Description
 ------------- | -------------
-**title** | required, the property title, it is used by the component Inspector in the CMS backend.
-**description** | required, the property description, it is used by the component Inspector in the CMS backend.
-**default** | optional, the default property value to use when the component is added to a page or layout in the CMS backend.
-**type** | optional, specifies the property type. The type defines the way how the property is displayed in the Inspector. Currently supported types are **string**, **checkbox**, **dropdown** and **set**. Default value: **string**.
-**validationPattern** | optional Regular Expression to use when a user enters the property value in the Inspector. The validation can be used only with **string** properties.
-**validationMessage** | optional error message to display if the validation fails.
-**required** | optional, forces field to be filled. Uses validationMessage when left empty.
-**placeholder** | optional placeholder for string and dropdown properties.
-**options** | optional array of options for dropdown properties.
-**depends** | an array of property names a dropdown property depends on. See the [dropdown properties](#dropdown-properties) below.
-**group** | an optional group name. Groups create sections in the Inspector simplifying the user experience. Use a same group name in multiple properties to combine them.
-**showExternalParam** | specifies visibility of the External Parameter editor for the property in the Inspector. Default value: **true**.
+`title` | required, the property title, it is used by the component Inspector in the CMS backend.
+`description` | required, the property description, it is used by the component Inspector in the CMS backend.
+`default` | optional, the default property value to use when the component is added to a page or layout in the CMS backend.
+`type` | optional, specifies the property type. The type defines the way how the property is displayed in the Inspector. Currently supported types are `string`, `checkbox`, `dropdown` and `set`. Default value: `string`.
+`validationPattern` | optional Regular Expression to use when a user enters the property value in the Inspector. The validation can be used only with `string` properties.
+`validationMessage` | optional error message to display if the validation fails.
+`required` | optional, forces field to be filled. Uses validationMessage when left empty.
+`placeholder` | optional placeholder for string and dropdown properties.
+`options` | optional array of options for dropdown properties.
+`depends` | an array of property names a dropdown property depends on. See the [dropdown properties](#dropdown-properties) below.
+`group` | an optional group name. Groups create sections in the Inspector simplifying the user experience. Use a same group name in multiple properties to combine them.
+`showExternalParam` | specifies visibility of the External Parameter editor for the property in the Inspector. Default value: `true`.
 
 Inside the component you can read the property value with the `property` method:
 

--- a/plugin-registration.md
+++ b/plugin-registration.md
@@ -192,22 +192,22 @@ The following methods are supported in the plugin registration class:
 
 Method | Description
 ------------- | -------------
-**pluginDetails()** | returns information about the plugin.
-**register()** | register method, called when the plugin is first registered.
-**boot()** | boot method, called right before the request route.
-**registerComponents()** | registers any [frontend components](components#component-registration) used by this plugin.
-**registerFormWidgets()** | registers any [backend form widgets](../backend/widgets#form-widget-registration) supplied by this plugin.
-**registerListColumnTypes()** | registers any [custom list column types](../backend/lists#custom-column-types) supplied by this plugin.
-**registerMailLayouts()** | registers any [mail view layouts](../services/mail#mail-template-registration) supplied by this plugin.
-**registerMailPartials()** | registers any [mail view partials](../services/mail#mail-template-registration) supplied by this plugin.
-**registerMailTemplates()** | registers any [mail view templates](../services/mail#mail-template-registration) supplied by this plugin.
-**registerMarkupTags()** | registers [additional markup tags](#extending-twig) that can be used in the CMS.
-**registerNavigation()** | registers [backend navigation menu items](#navigation-menus) for this plugin.
-**registerPermissions()** | registers any [backend permissions](../backend/users#permission-registration) used by this plugin.
-**registerReportWidgets()** | registers any [backend report widgets](../backend/widgets#report-widget-registration), including the dashboard widgets.
-**registerSchedule()** | registers [scheduled tasks](../plugin/scheduling#defining-schedules) that are executed on a regular basis.
-**registerSettings()** | registers any [backend configuration links](settings#link-registration) used by this plugin.
-**registerValidationRules()** | registers any [custom validators](../services/validation#custom-validation-rules) supplied by this plugin.
+`pluginDetails()` | returns information about the plugin.
+`register()` | register method, called when the plugin is first registered.
+`boot()` | boot method, called right before the request route.
+`registerComponents()` | registers any [frontend components](components#component-registration) used by this plugin.
+`registerFormWidgets()` | registers any [backend form widgets](../backend/widgets#form-widget-registration) supplied by this plugin.
+`registerListColumnTypes()` | registers any [custom list column types](../backend/lists#custom-column-types) supplied by this plugin.
+`registerMailLayouts()` | registers any [mail view layouts](../services/mail#mail-template-registration) supplied by this plugin.
+`registerMailPartials()` | registers any [mail view partials](../services/mail#mail-template-registration) supplied by this plugin.
+`registerMailTemplates()` | registers any [mail view templates](../services/mail#mail-template-registration) supplied by this plugin.
+`registerMarkupTags()` | registers [additional markup tags](#extending-twig) that can be used in the CMS.
+`registerNavigation()` | registers [backend navigation menu items](#navigation-menus) for this plugin.
+`registerPermissions()` | registers any [backend permissions](../backend/users#permission-registration) used by this plugin.
+`registerReportWidgets()` | registers any [backend report widgets](../backend/widgets#report-widget-registration), including the dashboard widgets.
+`registerSchedule()` | registers [scheduled tasks](../plugin/scheduling#defining-schedules) that are executed on a regular basis.
+`registerSettings()` | registers any [backend configuration links](settings#link-registration) used by this plugin.
+`registerValidationRules()` | registers any [custom validators](../services/validation#custom-validation-rules) supplied by this plugin.
 
 <a name="basic-plugin-information"></a>
 ### Basic plugin information
@@ -216,12 +216,12 @@ The `pluginDetails` is a required method of the plugin registration class. It sh
 
 Key | Description
 ------------- | -------------
-**name** | the plugin name, required.
-**description** | the plugin description, required.
-**author** | the plugin author name, required.
-**icon** | a name of the plugin icon. The full list of available icons can be found in the [UI documentation](../ui/icon). Any icon names provided by this font are valid, for example **icon-glass**, **icon-music**. This key is required if `iconSvg` is not set.
-**iconSvg** | an SVG icon to be used in place of the standard icon. The SVG icon should be a rectangle and can support colors. This key is required if `icon` is not set.
-**homepage** | a link to the author's website address, optional.
+`name` | the plugin name, required.
+`description` | the plugin description, required.
+`author` | the plugin author name, required.
+`icon` | a name of the plugin icon. The full list of available icons can be found in the [UI documentation](../ui/icon). Any icon names provided by this font are valid, for example **icon-glass**, **icon-music**. This key is required if `iconSvg` is not set.
+`iconSvg` | an SVG icon to be used in place of the standard icon. The SVG icon should be a rectangle and can support colors. This key is required if `icon` is not set.
+`homepage` | a link to the author's website address, optional.
 
 <a name="routing-initialization"></a>
 ## Routing and initialization
@@ -397,17 +397,17 @@ To make the sub-menu items visible, you may [set the navigation context](../back
 
 Key | Description
 ------------- | -------------
-**label** | specifies the menu label localization string key, required.
-**icon** | an icon name from the [Winter CMS icon collection](../ui/icon), optional.
-**iconSvg** | an SVG icon to be used in place of the standard icon, the SVG icon should be a rectangle and can support colors, optional.
-**url** | the URL the menu item should point to (ex. `Backend::url('author/plugin/controller/action')`, required.
-**counter** | a numeric value to output near the menu icon. The value should be a number or a callable returning a number, optional.
-**counterLabel** | a string value to describe the numeric reference in counter, optional.
-**badge** | a string value to output in place of the counter, the value should be a string and will override the badge property if set, optional.
-**attributes** | an associative array of attributes and values to apply to the menu item, optional.
-**permissions** | an array of permissions the backend user must have in order to view the menu item (Note: direct access of URLs still requires separate permission checks), optional.
-**code** | a string value that acts as an unique identifier for that menu option. **NOTE**: This is a system generated value and should not be provided when registering the navigation items.
-**owner** | a string value that specifies the menu items owner plugin or module in the format "Author.Plugin". **NOTE**: This is a system generated value and should not be provided when registering the navigation items.
+`label` | specifies the menu label localization string key, required.
+`icon` | an icon name from the [Winter CMS icon collection](../ui/icon), optional.
+`iconSvg` | an SVG icon to be used in place of the standard icon, the SVG icon should be a rectangle and can support colors, optional.
+`url` | the URL the menu item should point to (ex. `Backend::url('author/plugin/controller/action')`, required.
+`counter` | a numeric value to output near the menu icon. The value should be a number or a callable returning a number, optional.
+`counterLabel` | a string value to describe the numeric reference in counter, optional.
+`badge` | a string value to output in place of the counter, the value should be a string and will override the badge property if set, optional.
+`attributes` | an associative array of attributes and values to apply to the menu item, optional.
+`permissions` | an array of permissions the backend user must have in order to view the menu item (Note: direct access of URLs still requires separate permission checks), optional.
+`code` | a string value that acts as an unique identifier for that menu option. **NOTE**: This is a system generated value and should not be provided when registering the navigation items.
+`owner` | a string value that specifies the menu items owner plugin or module in the format "Author.Plugin". **NOTE**: This is a system generated value and should not be provided when registering the navigation items.
 
 <a name="registering-middleware"></a>
 ## Registering middleware
@@ -445,14 +445,14 @@ By default plugins are restricted from accessing certain areas of the system. Th
 
 Request | Description
 ------------- | -------------
-**/combine** | the asset combiner generator URL
-**/backend/system/updates** | the site updates context
-**/backend/system/install** | the installer path
-**/backend/backend/auth** | the backend authentication path (login, logout)
-**winter:up** | the CLI command that runs all pending migrations
-**winter:update** | the CLI command that triggers the update process
-**winter:env** | the CLI command that converts configuration files to environment variables in a `.env` file
-**winter:version** | the CLI command that detects the version of Winter CMS that is installed
+`/combine` | the asset combiner generator URL
+`/backend/system/updates` | the site updates context
+`/backend/system/install` | the installer path
+`/backend/backend/auth` | the backend authentication path (login, logout)
+`winter:up` | the CLI command that runs all pending migrations
+`winter:update` | the CLI command that triggers the update process
+`winter:env` | the CLI command that converts configuration files to environment variables in a `.env` file
+`winter:version` | the CLI command that detects the version of Winter CMS that is installed
 
 Define the `$elevated` property to grant elevated permissions for your plugin.
 

--- a/services-mail.md
+++ b/services-mail.md
@@ -91,10 +91,10 @@ The first argument in `sendTo` is used for the recipients can take different val
 
 Type | Description
 ------------- | -------------
-String | a single recipient address, with no name defined.
-Array | multiple recipients where the array key is the address and the value is the name.
-Object | a single recipient object, where the *email* property is used for the address and the *name* is optionally used for the name.
-Collection | a collection of recipient objects, as above.
+`String` | a single recipient address, with no name defined.
+`Array` | multiple recipients where the array key is the address and the value is the name.
+`Object` | a single recipient object, where the *email* property is used for the address and the *name* is optionally used for the name.
+`Collection` | a collection of recipient objects, as above.
 
 The complete signature of `sendTo` is as follows:
 


### PR DESCRIPTION
This pull request is to improve the usability of the documentation.
The problem is that browsers translate values in `strong` tags. Values in tags `code` are skipped by browsers during translation.

Now I see the page like this:

![2021-12-24_123724](https://user-images.githubusercontent.com/61043464/147365246-eeca732c-5bc4-4ed0-8124-02014af889fc.jpg)