### PR TITLE
Fix backend forms field types wrapping on small screens

### DIFF
--- a/backend-forms.md
+++ b/backend-forms.md
@@ -341,9 +341,14 @@ There are various native field types that can be used for the **type** setting. 
 
 <style>
     .collection-method-list {
-        column-count: 3; -moz-column-count: 3; -webkit-column-count: 3;
+        column-count: 2; -moz-column-count: 2; -webkit-column-count: 2;
         column-gap: 2em; -moz-column-gap: 2em; -webkit-column-gap: 2em;
     }
+@media (min-width: 576px) {
+    .collection-method-list {
+        column-count: 3; -moz-column-count: 3; -webkit-column-count: 3;
+    }
+}
 
     .collection-method-list a {
         display: block;


### PR DESCRIPTION
Field types wrap on mobile if using 3 columns.

Use 2 columns by default, 3 columns for width >= 576px.