### PR TITLE
Added link to image resizing options

### DIFF
--- a/backend/forms.md
+++ b/backend/forms.md
@@ -831,7 +831,7 @@ Option | Description
 `maxFilesize` | file size in Mb that are accepted by the uploader, optional. Default: from "upload_max_filesize" param value
 `useCaption` | allows a title and description to be set for the file. Default: true
 `prompt` | text to display for the upload button, applies to files only, optional.
-`thumbOptions` | options to pass to the thumbnail generating method for the file
+`thumbOptions` | options to pass to the thumbnail generating method for the file. See [Image Resizing](../services/image-resizing#available-parameters)
 `attachOnUpload` | Automatically attaches the uploaded file on upload if the parent record exists instead of using deferred binding to attach on save of the parent record. Defaults to false.
 
 > **NOTE:** Unlike the [Media Finder FormWidget](#media-finder), the File Upload FormWidget uses [database file attachments](../database/attachments); so the field name must match a valid `attachOne` or `attachMany` relationship on the Model associated with the Form. **IMPORTANT:** Having a database column with the name used by this field type (i.e. a database column with the name of an existing `attachOne` or `attachMany` relationship) **will** cause this FormWidget to break. Use database columns with the Media Finder FormWidget and file attachment relationships with the File Upload FormWidget.


### PR DESCRIPTION
Here in the table, `thumbOptions` parameter: https://wintercms.com/docs/v1.2/docs/backend/forms#file-upload

The link goes here: https://wintercms.com/docs/v1.2/docs/services/image-resizing#available-parameters