### PR TITLE
Updated jQuery version to 3.7.1

### DIFF
--- a/services/asset-compilation.md
+++ b/services/asset-compilation.md
@@ -105,7 +105,7 @@ The following aliases are supported:
 
 Alias | Description
 ------------- | -------------
-`@jquery` | Reference to the jQuery library (v3.4.0) used in the backend. (JavaScript)
+`@jquery` | Reference to the jQuery library (v3.7.1) used in the backend. (JavaScript)
 `@framework` | AJAX framework extras, subsitute for `{% framework %}` tag. (JavaScript)
 `@framework.extras` | AJAX framework extras, subsitute for `{% framework extras %}` tag. (JavaScript, CSS)
 `@framework.extras.js` | AJAX framework extras, (JavaScript)


### PR DESCRIPTION
a replacement for #66, a simple update of the docs to acknowledge the current version of jquery.
companion for [wintercms/winter#1026](https://github.com/wintercms/winter/pull/1026)

I did this in a new PR, because the old one was too old.
@LukeTowers, is this okay?
