### PR TITLE
Add example of Mail::fake() for unit testing in docs

### DIFF
--- a/services/mail.md
+++ b/services/mail.md
@@ -458,15 +458,17 @@ Another solution is to set a universal recipient of all e-mails sent by the fram
 ],
 ```
 
-### Mail Fake (Testing)
+### Pretend mail mode
 
-You may use the `Mail` facade's `fake` method to prevent mail from being sent during testing.
+You can dynamically disable sending mail using the `Mail::pretend` method. When the mailer is in pretend mode, messages will be written to your application's log files instead of being sent to the recipient.
 
 ```php
-Mail::fake();
+Mail::pretend();
 ```
 
-If you are sending a template you can, for example, validate that template was sent:
+### Unit testing
+
+When unit testing, you may want to utilize Laravel's `fake` method on the Mail facade.  This ensures your local configuration is ignored and mailing assertions can be performed without sending emails while your tests are running:
 
 ```php
 Mail::fake();
@@ -478,5 +480,3 @@ Mail::assertSent('this.is.my.email', function ($mail) {
     return $mail->hasTo('test@example.com');
 });
 ```
-
-Laravel has [additional information regarding Mail::fake](https://laravel.com/docs/9.x/mocking#mail-fake).

--- a/services/mail.md
+++ b/services/mail.md
@@ -458,10 +458,25 @@ Another solution is to set a universal recipient of all e-mails sent by the fram
 ],
 ```
 
-### Pretend mail mode
+### Mail Fake (Testing)
 
-You can dynamically disable sending mail using the `Mail::pretend` method. When the mailer is in pretend mode, messages will be written to your application's log files instead of being sent to the recipient.
+You may use the `Mail` facade's `fake` method to prevent mail from being sent during testing.
 
 ```php
-Mail::pretend();
+Mail::fake();
 ```
+
+If you are sending a template you can, for example, validate that template was sent:
+
+```php
+Mail::fake();
+
+// ... Run code that sends email 'this.is.my.email' template.
+
+// Check that the email was sent
+Mail::assertSent('this.is.my.email', function ($mail) {
+    return $mail->hasTo('test@example.com');
+});
+```
+
+Laravel has [additional information regarding Mail::fake](https://laravel.com/docs/9.x/mocking#mail-fake).


### PR DESCRIPTION
It appears this section of the docs is outdated.  The `Mail::pretend()` method was a part of Laravel's `Mail` facade in versions prior to Laravel 5.5. This method was used to prevent emails from actually being sent during testing, and instead write them to the application's log files.

However, this method has been removed in Laravel 5.5 and later versions. The recommended way to prevent emails from being sent during testing is to use the `Mail::fake()` method, which is part of the `Mail` facade in Laravel 5.5 and later versions.

There is one example added here that is not very clear in the Laravel documentation since theirs only passes through classes, and checking for templates will be very relevant to WinterCMS developers.