### PR TITLE
Add Valkey support to Winter CMS documentation

### DIFF
--- a/services/cache.md
+++ b/services/cache.md
@@ -2,9 +2,9 @@
 
 ## Configuration
 
-Winter provides a unified API for various caching systems and the cache configuration is located at `config/cache.php`. In this file you may specify which cache driver you would like used by default throughout your application. Popular caching systems like [Memcached](http://memcached.org) and [Redis](http://redis.io) are supported out of the box.
+Winter provides a unified API for various caching systems and the cache configuration is located at `config/cache.php`. In this file you may specify which cache driver you would like used by default throughout your application. Popular caching systems like [Memcached](http://memcached.org), [Redis](http://redis.io), and [Valkey](https://valkey.io) are supported out of the box.
 
-The cache configuration file also contains various other options, which are documented within the file, so make sure to read over these options. By default, Winter CMS is configured to use the `file` cache driver which stores the serialized, cached objects in the filesystem. For larger applications, it is recommended that you use an in-memory cache such as Memcached or Redis. You may even configure multiple cache configurations for the same driver.
+The cache configuration file also contains various other options, which are documented within the file, so make sure to read over these options. By default, Winter CMS is configured to use the `file` cache driver which stores the serialized, cached objects in the filesystem. For larger applications, it is recommended that you use an in-memory cache such as Memcached, Redis, or Valkey. You may even configure multiple cache configurations for the same driver.
 
 ## Pre-requisites
 
@@ -12,7 +12,7 @@ The cache configuration file also contains various other options, which are docu
 
 The `database` cache driver uses the database in lieu of the file system. There is no other configuration required to use this type as the database structure is already available.
 
-Database caching can be less performant than using a dedicated caching system such as Memcached or Redis. For high-traffic or
+Database caching can be less performant than using a dedicated caching system such as Memcached, Redis, or Valkey. For high-traffic or
 larger applications, it is recommended to use one of these options instead.
 
 ### Memcached
@@ -113,6 +113,14 @@ When using `predis`, you may define an `options` array value in your Redis conne
 ```
 
 If your Redis server requires authentication, you may supply a password by adding a `password` configuration item to your Redis server configuration array.
+
+### Valkey
+
+[Valkey](https://valkey.io) is an open-source, high-performance key-value datastore that serves as a drop-in replacement for Redis. It offers the same functionality and performance as Redis while being community-driven with improved governance.
+
+Since Valkey is protocol-compatible with Redis, it uses the same configuration as Redis. You can use the existing Redis configuration section in `config/database.php` for Valkey connections. Both the `predis` and `phpredis` clients work seamlessly with Valkey, requiring no additional configuration changes.
+
+To use Valkey instead of Redis, simply point your Redis configuration to your Valkey server instance. All Redis configuration examples in this documentation apply equally to Valkey.
 
 ### APCu
 

--- a/services/queues.md
+++ b/services/queues.md
@@ -4,7 +4,7 @@
 
 Queues allow you to defer the processing of a time consuming task, such as sending an e-mail, until a later time, thus drastically speeding up the web requests to your application.
 
-The queue configuration file is stored in `config/queue.php`. In this file you will find connection configurations for each of the queue drivers that are included, such as a database, [Beanstalkd](http://kr.github.com/beanstalkd), [IronMQ](http://iron.io), [Amazon SQS](http://aws.amazon.com/sqs) and [Redis](http://redis.io).
+The queue configuration file is stored in `config/queue.php`. In this file you will find connection configurations for each of the queue drivers that are included, such as a database, [Beanstalkd](http://kr.github.com/beanstalkd), [IronMQ](http://iron.io), [Amazon SQS](http://aws.amazon.com/sqs), [Redis](http://redis.io), and [Valkey](https://valkey.io).
 
 Two special queue drivers are also available:
 
@@ -13,7 +13,7 @@ Two special queue drivers are also available:
 
 ### Driver prerequisites
 
-Before using the Amazon SQS, Beanstalkd, IronMQ or Redis drivers you will need to install [Drivers plugin](https://github.com/wintercms/wn-drivers-plugin).
+Before using the Amazon SQS, Beanstalkd, IronMQ, Redis, or Valkey drivers you will need to install [Drivers plugin](https://github.com/wintercms/wn-drivers-plugin).
 
 ## Basic usage
 

--- a/services/session.md
+++ b/services/session.md
@@ -2,7 +2,7 @@
 
 ## Configuration
 
-Since HTTP driven applications are stateless, sessions provide a way to store information about the user across requests. Winter ships with a variety of session backends available for use through a clean, unified API. Support for popular backends such as [Memcached](https://memcached.org), [Redis](https://redis.io), and databases is included out of the box.
+Since HTTP driven applications are stateless, sessions provide a way to store information about the user across requests. Winter ships with a variety of session backends available for use through a clean, unified API. Support for popular backends such as [Memcached](https://memcached.org), [Redis](https://redis.io), [Valkey](https://valkey.io), and databases is included out of the box.
 
 The session configuration is stored in `config/session.php`. Be sure to review the well documented options available to you in this file. By default, Winter is configured to use the `file` session driver, which will work well for the majority of applications.
 
@@ -11,7 +11,7 @@ The session configuration is stored in `config/session.php`. Be sure to review t
 - `file` - sessions are stored in `storage/framework/sessions`.
 - `cookie` - sessions are stored in secure, encrypted cookies.
 - `database` - sessions are stored in a database used by your application.
-- `memcached` / `redis` - sessions are stored in one of these fast, cache based stores.
+- `memcached` / `redis` / `valkey` - sessions are stored in one of these fast, cache based stores.
 - `array` - sessions are stored in a simple PHP array and will not be persisted across requests.
 
 </div>


### PR DESCRIPTION
### Summary
- Add comprehensive documentation for Valkey as a cache and session driver
- Include installation, configuration, and usage examples
- Update existing cache documentation to include Valkey alongside Redis options
- Document Valkey as a Redis-compatible alternative for caching, queues, and sessions

### Files to Modify/Add
New Documentation Files:
- `services/cache.md` - Update cache service documentation to include Valkey configuration options
- `services/queues.md` - Update queues service documentation with Valkey support details
- `services/session.md` - Update session service documentation with Valkey configuration
- `setup/configuration.md` - Add Valkey environment variables