### PR TITLE
Document 'parent' key for theme fallback

### DIFF
--- a/themes/development.md
+++ b/themes/development.md
@@ -25,6 +25,7 @@ Field | Description
 `form` | a configuration array or reference to a form field definition file, used for [theme customization](#theme-customization), optional.
 `require` | an array of plugin names used for [theme dependencies](#theme-dependencies), optional.
 `mix` | an object that defines Mix packages contained in your theme for [asset compilation](../console/asset-compilation).
+`parent` | define a parent theme that this theme will use as a fallback if the file is not present
 
 Example of the theme information file:
 

--- a/themes/development.md
+++ b/themes/development.md
@@ -25,7 +25,7 @@ Field | Description
 `form` | a configuration array or reference to a form field definition file, used for [theme customization](#theme-customization), optional.
 `require` | an array of plugin names used for [theme dependencies](#theme-dependencies), optional.
 `mix` | an object that defines Mix packages contained in your theme for [asset compilation](../console/asset-compilation).
-`parent` | define a parent theme that this theme will use as a fallback if the file is not present, optional
+`parent` | define a parent theme that this theme will use as a fallback if the file is not present, optional.
 
 Example of the theme information file:
 

--- a/themes/development.md
+++ b/themes/development.md
@@ -25,7 +25,7 @@ Field | Description
 `form` | a configuration array or reference to a form field definition file, used for [theme customization](#theme-customization), optional.
 `require` | an array of plugin names used for [theme dependencies](#theme-dependencies), optional.
 `mix` | an object that defines Mix packages contained in your theme for [asset compilation](../console/asset-compilation).
-`parent` | define a parent theme that this theme will use as a fallback if the file is not present
+`parent` | define a parent theme that this theme will use as a fallback if the file is not present, optional
 
 Example of the theme information file:
 


### PR DESCRIPTION
Added 'parent' key to theme information documentation.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->