### PR TITLE
Typo in readme Line 85

### DIFF
--- a/backend/widgets.md
+++ b/backend/widgets.md
@@ -82,7 +82,7 @@ protected function loadAssets()
 {
     $this->addCss('css/form.css');
 
-    $this->addJs('css/form.js', 'Acme.Test');
+    $this->addJs('js/form.js', 'Acme.Test');
 }
 ```
 


### PR DESCRIPTION
Replace css for js

Minor typo in the readme.

```
$this->addJs('css/form.js', 'Acme.Test');
```

```
$this->addJs('js/form.js', 'Acme.Test');
```